### PR TITLE
Fixed bug #77616 (Windows x64 build not working).

### DIFF
--- a/xdiff.c
+++ b/xdiff.c
@@ -27,7 +27,14 @@
 #include "ext/standard/info.h"
 #include "php_xdiff.h"
 
+#ifdef _MSC_VER
+/* libxdiff is compiled with /Zp1 */
+#pragma pack(push, 1)
+#endif
 #include <xdiff.h>
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 /* Not exported by header file */
 extern char libxdiff_version[];


### PR DESCRIPTION
The current Windows x64 build doesn't work due to the alignment mismatch between libxdiff and PHP.

As reported on [bugs.php.net](https://bugs.php.net/bug.php?id=77616), xdiff_string_rabdiff() returns invalid diff result.
Also xdiff_string_diff() fails by trying to allocate too much memory inside append_string().

This is more like a bug of libxdiff not having alignment pragma on its header file, but its repo seems to be dead.