### PR TITLE
 Fixed bug #77826 (xdiff_string_bpatch wrong return value on error).

### DIFF
--- a/tests/error-bpatch.phpt
+++ b/tests/error-bpatch.phpt
@@ -1,0 +1,13 @@
+--TEST--
+xdiff_string_bpatch() error
+--SKIPIF--
+<?php if (!extension_loaded("xdiff")) print "skip"; ?>
+--FILE--
+<?php
+$str = '0123456789';
+$patch = hex2bin('0d02f50a0b000000010a31323334353637383930');
+$result = xdiff_string_bpatch($str, $patch);
+var_dump($result);
+?>
+--EXPECT--
+bool(false)

--- a/tests/error-patch.phpt
+++ b/tests/error-patch.phpt
@@ -1,0 +1,13 @@
+--TEST--
+xdiff_string_patch() error
+--SKIPIF--
+<?php if (!extension_loaded("xdiff")) print "skip"; ?>
+--FILE--
+<?php
+$str = "123\n456\n";
+$patch = "@@ -0,0 +0,0 @@\n 789\n +012\n 345\n";
+$result = xdiff_string_patch($str, $patch);
+var_dump($result);
+?>
+--EXPECT--
+bool(false)

--- a/xdiff.c
+++ b/xdiff.c
@@ -454,7 +454,7 @@ PHP_FUNCTION(xdiff_file_patch)
 	error_output.outf = append_string;
 
 	retval = make_patch(src_path->val, patch_path->val, &output, &error_output, flags);
-	if (retval < 0)
+	if (!retval)
 		goto out_free_string;
 
 	if (error_string.size > 0) {
@@ -504,7 +504,7 @@ PHP_FUNCTION(xdiff_string_patch)
 	error_output.outf = append_string;
 
 	retval = make_patch_str(src->val, src->len, patch->val, patch->len, &output, &error_output, flags);
-	if (retval < 0)
+	if (!retval)
 		goto out_free_error_string;
 
 	if (error_string.size > 0 && error_ref) {
@@ -582,7 +582,7 @@ PHP_FUNCTION(xdiff_string_bpatch)
 	output.outf = append_string;
 
 	retval = make_bpatch_str(src->val, src->len, patch->val, patch->len, &output);
-	if (retval < 0)
+	if (!retval)
 		goto out_free_string;
 
 	RETVAL_STRINGL(output_string.ptr, output_string.size);


### PR DESCRIPTION
Fix bug where xdiff_string_patch()/xdiff_string_bpatch() returns empty string instead of false when broken input is passed.

Also fix tests where:
- binary files in tests/ is broken (CR(LF) is turned into LF.)
- merge.h (diff file created during test) is added to repository.