### PR TITLE
Fixed bug #77856 (xdiff_string_patch() no $error returned).

### DIFF
--- a/tests/error-patch2.phpt
+++ b/tests/error-patch2.phpt
@@ -1,0 +1,15 @@
+--TEST--
+xdiff_string_patch() rejection
+--SKIPIF--
+<?php if (!extension_loaded("xdiff")) print "skip"; ?>
+--FILE--
+<?php
+$str = "123\n456\n";
+$patch = "@@ -1,2 +1,3 @@\n 789\n+012\n 345\n";
+$result = xdiff_string_patch($str, $patch, XDIFF_PATCH_NORMAL, $error);
+var_dump($result === $str);
+var_dump($error === $patch);
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/xdiff.c
+++ b/xdiff.c
@@ -508,7 +508,7 @@ PHP_FUNCTION(xdiff_string_patch)
 		goto out_free_error_string;
 
 	if (error_string.size > 0 && error_ref) {
-		ZVAL_STRINGL(error_ref, error_string.ptr, error_string.size);
+		ZEND_TRY_ASSIGN_REF_STRINGL(error_ref, error_string.ptr, error_string.size);
 	}
 
 	if (output_string.size > 0) {
@@ -678,7 +678,7 @@ PHP_FUNCTION(xdiff_string_merge3)
 		goto out_free_error_string;
 
 	if (error_string.size > 0 && error_ref) {
-		ZVAL_STRINGL(error_ref, error_string.ptr, error_string.size);
+		ZEND_TRY_ASSIGN_REF_STRINGL(error_ref, error_string.ptr, error_string.size);
 	}
 
 	if (output_string.size > 0) {


### PR DESCRIPTION
The fourth parameter of xdiff_string_patch() $error should return failed hunks of the patch, but nothing is returned.