### PR TITLE
Fixed bug #81552 (xdiff_string_bpatch() and others missing)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -78,6 +78,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     <file name="033.phpt" role="test" />
     <file name="034.phpt" role="test" />
     <file name="035.phpt" role="test" />
+    <file name="bug81552.phpt" role="test" />
     <file name="context1.patch" role="test" />
     <file name="context5.patch" role="test" />
     <file name="file.1" role="test" />

--- a/tests/bug81552.phpt
+++ b/tests/bug81552.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #81552: xdiff_string_bpatch() and others missing
+--SKIPIF--
+<?php if (!extension_loaded("xdiff")) print "skip"; ?>
+--FILE--
+<?php
+$s1 = 'The quick brown fox jumps over the lazy dog.';
+$s2 = 'The quick brown fox jumps over the lazy cog.';
+var_dump(xdiff_string_bpatch($s1, xdiff_string_bdiff($s1, $s2)));
+xdiff_file_bdiff(__DIR__ . '/file.1', __DIR__ . '/file.2', __DIR__ . '/file.bd81552');
+xdiff_file_bpatch(__DIR__ . '/file.1', __DIR__ . '/file.bd81552', __DIR__ . '/file.p81552');
+$a = file_get_contents(__DIR__ . '/file.2');
+$b = file_get_contents(__DIR__ . '/file.p81552');
+var_dump(strcmp($a, $b));
+unlink(__DIR__ . '/file.bd81552');
+unlink(__DIR__ . '/file.p81552');
+?>
+--EXPECT--
+string(44) "The quick brown fox jumps over the lazy cog."
+int(0)

--- a/xdiff.stub.php
+++ b/xdiff.stub.php
@@ -1,33 +1,26 @@
 <?php
 /** @generate-function-entries */
 
-/**
- * @param string $str1
- * @param string $str2
- * @param int $context
- * @param bool $minimal
- * @return string|false
- */
+/** @return string|false */
 function xdiff_string_diff(string $str1, string $str2, int $context = 3, bool $minimal = false) {}
 
 function xdiff_file_diff(string $file1, string $file2, string $dest, int $context = 3, bool $minimal = false): bool {}
 
+/** @return string|false */
+function xdiff_string_bdiff(string $str1, string $str2) {}
+
 /**
- * @param string $str1
- * @param string $str2
  * @return string|false
  * @alias xdiff_string_bdiff
  */
 function xdiff_string_diff_binary(string $str1, string $str2) {}
 
+function xdiff_file_bdiff(string $file1, string $file2, string $dest): bool {}
+
 /** @alias xdiff_file_bdiff */
 function xdiff_file_diff_binary(string $file1, string $file2, string $dest): bool {}
 
-/**
- * @param string $str1
- * @param string $str2
- * @return string|false
- */
+/** @return string|false */
 function xdiff_string_rabdiff(string $str1, string $str2) {}
 
 function xdiff_file_rabdiff(string $file1, string $file2, string $dest): bool {}
@@ -36,49 +29,28 @@ function xdiff_file_bdiff_size(string $file1, string $file2, string $dest): bool
 
 function xdiff_string_bdiff_size(string $file1, string $file2, string $dest): bool {}
 
-/**
- * @param string $file
- * @param string $patch
- * @param string $dest
- * @param int $flags
- * @return string|bool
- */
+/** @return string|bool */
 function xdiff_file_patch(string $file, string $patch, string $dest, int $flags=XDIFF_PATCH_NORMAL) {}
 
-/**
- * @param string $file
- * @param string $patch
- * @param int $flags
- * @param string $error
- * @return string|bool
- */
+/** @return string|bool */
 function xdiff_string_patch(string $file, string $patch, int $flags=XDIFF_PATCH_NORMAL, string &$error=null) {}
+
+function xdiff_file_bpatch(string $file, string $patch, string $dest): bool {}
 
 /** @alias xdiff_file_bpatch */
 function xdiff_file_patch_binary(string $file, string $patch, string $dest): bool {}
 
+/** @return string|false */
+function xdiff_string_bpatch(string $str, string $patch) {}
+
 /**
- * @param string $file
- * @param string $patch
  * @return string|false
  * @alias xdiff_string_bpatch
  */
 function xdiff_string_patch_binary(string $str, string $patch) {}
 
-/**
- * @param string $file1
- * @param string $file2
- * @param string $file3
- * @param string $dest
- * @return string|bool
- */
+/** @return string|bool */
 function xdiff_file_merge3(string $file1, string $file2, string $file3, string $dest) {}
 
-/**
- * @param string $str1
- * @param string $str2
- * @param string $str3
- * @param string $error
- * @return string|bool
- */
+/** @return string|bool */
 function xdiff_string_merge3(string $str1, string $str2, string $str3, string &$error=null) {}

--- a/xdiff_arginfo.h
+++ b/xdiff_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ec3a63aa4462f084433c3576ad532de87da7f867 */
+ * Stub hash: 90bf8c5e8be3dd1673bdadd36d5cebd846ff425d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_xdiff_string_diff, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, str1, IS_STRING, 0)
@@ -16,24 +16,28 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdiff_file_diff, 0, 3, _IS_BOOL,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, minimal, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_xdiff_string_diff_binary, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_xdiff_string_bdiff, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, str1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, str2, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdiff_file_diff_binary, 0, 3, _IS_BOOL, 0)
+#define arginfo_xdiff_string_diff_binary arginfo_xdiff_string_bdiff
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdiff_file_bdiff, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, file1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, file2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, dest, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_xdiff_string_rabdiff arginfo_xdiff_string_diff_binary
+#define arginfo_xdiff_file_diff_binary arginfo_xdiff_file_bdiff
 
-#define arginfo_xdiff_file_rabdiff arginfo_xdiff_file_diff_binary
+#define arginfo_xdiff_string_rabdiff arginfo_xdiff_string_bdiff
 
-#define arginfo_xdiff_file_bdiff_size arginfo_xdiff_file_diff_binary
+#define arginfo_xdiff_file_rabdiff arginfo_xdiff_file_bdiff
 
-#define arginfo_xdiff_string_bdiff_size arginfo_xdiff_file_diff_binary
+#define arginfo_xdiff_file_bdiff_size arginfo_xdiff_file_bdiff
+
+#define arginfo_xdiff_string_bdiff_size arginfo_xdiff_file_bdiff
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_xdiff_file_patch, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, file, IS_STRING, 0)
@@ -49,16 +53,20 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_xdiff_string_patch, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(1, error, IS_STRING, 0, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdiff_file_patch_binary, 0, 3, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xdiff_file_bpatch, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, file, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, patch, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, dest, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_xdiff_string_patch_binary, 0, 0, 2)
+#define arginfo_xdiff_file_patch_binary arginfo_xdiff_file_bpatch
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_xdiff_string_bpatch, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, str, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, patch, IS_STRING, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_xdiff_string_patch_binary arginfo_xdiff_string_bpatch
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_xdiff_file_merge3, 0, 0, 4)
 	ZEND_ARG_TYPE_INFO(0, file1, IS_STRING, 0)
@@ -94,7 +102,9 @@ ZEND_FUNCTION(xdiff_string_merge3);
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(xdiff_string_diff, arginfo_xdiff_string_diff)
 	ZEND_FE(xdiff_file_diff, arginfo_xdiff_file_diff)
+	ZEND_FE(xdiff_string_bdiff, arginfo_xdiff_string_bdiff)
 	ZEND_FALIAS(xdiff_string_diff_binary, xdiff_string_bdiff, arginfo_xdiff_string_diff_binary)
+	ZEND_FE(xdiff_file_bdiff, arginfo_xdiff_file_bdiff)
 	ZEND_FALIAS(xdiff_file_diff_binary, xdiff_file_bdiff, arginfo_xdiff_file_diff_binary)
 	ZEND_FE(xdiff_string_rabdiff, arginfo_xdiff_string_rabdiff)
 	ZEND_FE(xdiff_file_rabdiff, arginfo_xdiff_file_rabdiff)
@@ -102,7 +112,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(xdiff_string_bdiff_size, arginfo_xdiff_string_bdiff_size)
 	ZEND_FE(xdiff_file_patch, arginfo_xdiff_file_patch)
 	ZEND_FE(xdiff_string_patch, arginfo_xdiff_string_patch)
+	ZEND_FE(xdiff_file_bpatch, arginfo_xdiff_file_bpatch)
 	ZEND_FALIAS(xdiff_file_patch_binary, xdiff_file_bpatch, arginfo_xdiff_file_patch_binary)
+	ZEND_FE(xdiff_string_bpatch, arginfo_xdiff_string_bpatch)
 	ZEND_FALIAS(xdiff_string_patch_binary, xdiff_string_bpatch, arginfo_xdiff_string_patch_binary)
 	ZEND_FE(xdiff_file_merge3, arginfo_xdiff_file_merge3)
 	ZEND_FE(xdiff_string_merge3, arginfo_xdiff_string_merge3)


### PR DESCRIPTION
Added stubs for the actual names of the functions for which aliases
exist. These are the same except that the names are changed and @alias
is removed from the doc comments.

Regenerated xdiff_arginfo.h. I had to remove the unnecessary PHPDoc
types in order for this to succeed using the PHP 8.1 version of
gen_stub.php. (PHP 8.0's version of the script doesn't complain.)