### PR TITLE
Add missing functions.

### DIFF
--- a/tests/functions.phpt
+++ b/tests/functions.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Check for xdiff functions
+--SKIPIF--
+<?php if (!extension_loaded("xdiff")) print "skip"; ?>
+--FILE--
+<?php
+$funcs = get_extension_funcs('xdiff');
+sort($funcs, SORT_STRING);
+foreach ($funcs as $func) {
+    echo "$func\n";
+}
+?>
+--EXPECT--
+xdiff_file_bdiff
+xdiff_file_bdiff_size
+xdiff_file_bpatch
+xdiff_file_diff
+xdiff_file_diff_binary
+xdiff_file_merge3
+xdiff_file_patch
+xdiff_file_patch_binary
+xdiff_file_rabdiff
+xdiff_string_bdiff
+xdiff_string_bdiff_size
+xdiff_string_bpatch
+xdiff_string_diff
+xdiff_string_diff_binary
+xdiff_string_merge3
+xdiff_string_patch
+xdiff_string_patch_binary
+xdiff_string_rabdiff

--- a/xdiff_arginfo.h
+++ b/xdiff_arginfo.h
@@ -94,6 +94,8 @@ ZEND_FUNCTION(xdiff_string_merge3);
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(xdiff_string_diff, arginfo_xdiff_string_diff)
 	ZEND_FE(xdiff_file_diff, arginfo_xdiff_file_diff)
+	ZEND_FE(xdiff_string_bdiff, arginfo_xdiff_string_diff_binary)
+	ZEND_FE(xdiff_file_bdiff, arginfo_xdiff_file_diff_binary)
 	ZEND_FALIAS(xdiff_string_diff_binary, xdiff_string_bdiff, arginfo_xdiff_string_diff_binary)
 	ZEND_FALIAS(xdiff_file_diff_binary, xdiff_file_bdiff, arginfo_xdiff_file_diff_binary)
 	ZEND_FE(xdiff_string_rabdiff, arginfo_xdiff_string_rabdiff)
@@ -102,6 +104,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(xdiff_string_bdiff_size, arginfo_xdiff_string_bdiff_size)
 	ZEND_FE(xdiff_file_patch, arginfo_xdiff_file_patch)
 	ZEND_FE(xdiff_string_patch, arginfo_xdiff_string_patch)
+	ZEND_FE(xdiff_file_bpatch, arginfo_xdiff_file_patch_binary)
+	ZEND_FE(xdiff_string_bpatch, arginfo_xdiff_string_patch_binary)
 	ZEND_FALIAS(xdiff_file_patch_binary, xdiff_file_bpatch, arginfo_xdiff_file_patch_binary)
 	ZEND_FALIAS(xdiff_string_patch_binary, xdiff_string_bpatch, arginfo_xdiff_string_patch_binary)
 	ZEND_FE(xdiff_file_merge3, arginfo_xdiff_file_merge3)


### PR DESCRIPTION
Fix to export the missing functions below:
```
xdiff_file_bdiff()
xdiff_file_bpatch()
xdiff_string_bdiff()
xdiff_string_bpatch()
```