### PR TITLE
Fix memory leak when $error on input is refcounted.

### DIFF
--- a/xdiff.c
+++ b/xdiff.c
@@ -57,6 +57,15 @@
 # pragma pack(pop)
 #endif
 
+#ifndef ZEND_TRY_ASSIGN_REF_STRINGL
+#define ZEND_TRY_ASSIGN_REF_STRINGL(zv, s, l)  do { \
+	zval *_zv = (zv); \
+	ZVAL_DEREF(_zv); \
+	zval_ptr_dtor(_zv); \
+	ZVAL_STRINGL(_zv, (s), (l)); \
+} while (0)
+#endif
+
 /* Not exported by header file */
 extern char libxdiff_version[];
 
@@ -505,8 +514,7 @@ PHP_FUNCTION(xdiff_string_patch)
 		goto out_free_error_string;
 
 	if (error_string.size > 0 && error_ref) {
-		ZVAL_DEREF(error_ref);
-		ZVAL_STRINGL(error_ref, error_string.ptr, error_string.size);
+		ZEND_TRY_ASSIGN_REF_STRINGL(error_ref, error_string.ptr, error_string.size);
 	}
 
 	if (output_string.size > 0) {
@@ -676,8 +684,7 @@ PHP_FUNCTION(xdiff_string_merge3)
 		goto out_free_error_string;
 
 	if (error_string.size > 0 && error_ref) {
-		ZVAL_DEREF(error_ref);
-		ZVAL_STRINGL(error_ref, error_string.ptr, error_string.size);
+		ZEND_TRY_ASSIGN_REF_STRINGL(error_ref, error_string.ptr, error_string.size);
 	}
 
 	if (output_string.size > 0) {


### PR DESCRIPTION
`$error` parameter of patch/merge functions leak memory only if the parameter value passed-in is refcounted.

I'm sorry that I failed to clarify about this update in the PR in #4 #8 months back.