### PR TITLE
memory safety cleanup

### DIFF
--- a/tests/file_bpatch_retval.phpt
+++ b/tests/file_bpatch_retval.phpt
@@ -1,0 +1,21 @@
+--TEST--
+xdiff_file_bpatch() return value on success and failure
+--SKIPIF--
+<?php if (!extension_loaded("xdiff")) print "skip"; ?>
+--FILE--
+<?php
+$result = xdiff_file_bpatch(__DIR__ . '/file.1', __DIR__ . '/file.bdiff', __DIR__ . '/file.bpatch_out');
+var_dump($result);
+$a = file_get_contents(__DIR__ . '/file.2');
+$b = file_get_contents(__DIR__ . '/file.bpatch_out');
+echo "content match: " . (strcmp($a, $b) === 0 ? "yes" : "no") . "\n";
+unlink(__DIR__ . '/file.bpatch_out');
+
+$result = xdiff_file_bpatch(__DIR__ . '/file.1', __DIR__ . '/file.1', __DIR__ . '/file.bpatch_out2');
+var_dump($result);
+@unlink(__DIR__ . '/file.bpatch_out2');
+?>
+--EXPECT--
+bool(true)
+content match: yes
+bool(false)

--- a/xdiff.c
+++ b/xdiff.c
@@ -82,17 +82,17 @@ static int init_string(struct string_buffer *string);
 static void free_string(struct string_buffer *string);
 
 static int make_diff(char *filepath1, char *filepath2, xdemitcb_t *output, int context, int minimal);
-static int make_diff_str(char *str1, int size1, char *str2, int size2,  xdemitcb_t *output, int context, int minimal);
+static int make_diff_str(char *str1, size_t size1, char *str2, size_t size2,  xdemitcb_t *output, int context, int minimal);
 static int make_bdiff(char *filepath1, char *filepath2, xdemitcb_t *output);
-static int make_bdiff_str(char *str1, int size1, char *str2, int size2, xdemitcb_t *output);
+static int make_bdiff_str(char *str1, size_t size1, char *str2, size_t size2, xdemitcb_t *output);
 static int make_patch(char *file_path, char *patch_path, xdemitcb_t *output, xdemitcb_t *error, int flags);
-static int make_patch_str(char *file, int size1, char *patch, int size2, xdemitcb_t *output, xdemitcb_t *error, int flags);
+static int make_patch_str(char *file, size_t size1, char *patch, size_t size2, xdemitcb_t *output, xdemitcb_t *error, int flags);
 static int make_bpatch(char *file_path, char *patch_path, xdemitcb_t *output);
-static int make_bpatch_str(char *file, int size1, char *patch, int size2, xdemitcb_t *output);
+static int make_bpatch_str(char *file, size_t size1, char *patch, size_t size2, xdemitcb_t *output);
 static int make_merge3(char *filepath1, char *filepath2, char *filepath3, xdemitcb_t *output, xdemitcb_t *error);
-static int make_merge3_str(char *content1, int size1, char *content2, int size2, char *content3, int size3, xdemitcb_t *output, xdemitcb_t *error);
+static int make_merge3_str(char *content1, size_t size1, char *content2, size_t size2, char *content3, size_t size3, xdemitcb_t *output, xdemitcb_t *error);
 static int make_rabdiff(char *filepath1, char *filepath2, xdemitcb_t *output);
-static int make_rabdiff_str(char *str1, int size1, char *str2, int size2, xdemitcb_t *output);
+static int make_rabdiff_str(char *str1, size_t size1, char *str2, size_t size2, xdemitcb_t *output);
 
 static void *xdiff_malloc(void *foo, unsigned int size)
 {
@@ -187,8 +187,13 @@ PHP_FUNCTION(xdiff_string_diff)
 	output.priv= &string;
 	output.outf = append_string;
 
-	make_diff_str(str1->val, str1->len, str2->val, str2->len, &output, context, minimal);
+	retval = make_diff_str(str1->val, str1->len, str2->val, str2->len, &output, context, minimal);
+	if (!retval)
+		goto out_free_string;
+
 	RETVAL_STRINGL(string.ptr, string.size);
+
+out_free_string:
 	free_string(&string);
 out:
 	return;
@@ -254,10 +259,14 @@ PHP_FUNCTION(xdiff_string_bdiff)
 	output.priv= &string;
 	output.outf = append_string;
 
-	make_bdiff_str(str1->val, str1->len, str2->val, str2->len, &output);
-	RETVAL_STRINGL(string.ptr, string.size);
-	free_string(&string);
+	retval = make_bdiff_str(str1->val, str1->len, str2->val, str2->len, &output);
+	if (!retval)
+		goto out_free_string;
 
+	RETVAL_STRINGL(string.ptr, string.size);
+
+out_free_string:
+	free_string(&string);
 out:
 	return;
 }
@@ -320,10 +329,14 @@ PHP_FUNCTION(xdiff_string_rabdiff)
 	output.priv= &string;
 	output.outf = append_string;
 
-	make_rabdiff_str(str1->val, str1->len, str2->val, str2->len, &output);
-	RETVAL_STRINGL(string.ptr, string.size);
-	free_string(&string);
+	retval = make_rabdiff_str(str1->val, str1->len, str2->val, str2->len, &output);
+	if (!retval)
+		goto out_free_string;
 
+	RETVAL_STRINGL(string.ptr, string.size);
+
+out_free_string:
+	free_string(&string);
 out:
 	return;
 }
@@ -557,7 +570,7 @@ PHP_FUNCTION(xdiff_file_bpatch)
 	retval = make_bpatch(src_path->val, patch_path->val, &output);
 	php_stream_close(output_stream);
 
-	if (retval == 0)
+	if (retval)
 		RETVAL_TRUE;
 
 out:
@@ -728,7 +741,9 @@ static int load_mm_file(const char *filepath, mmfile_t *dest)
 	if (!ptr)
 		goto out_free_mmfile;
 
-	php_stream_read(src, ptr, filesize);
+	if (php_stream_read(src, ptr, filesize) != filesize)
+		goto out_free_mmfile;
+
 	php_stream_close(src);
 
 	return 1;
@@ -773,6 +788,7 @@ static int append_string(void *ptr, mmbuffer_t *buffer, int array_size)
 		new_ptr = erealloc(string->ptr, string->size + buffer[i].size + 1);
 		if (!new_ptr) {
 			efree(string->ptr);
+			string->ptr = NULL;
 			return -1;
 		}
 
@@ -849,7 +865,7 @@ out:
 	return result;
 }
 
-static int make_diff_str(char *str1, int size1, char *str2, int size2, xdemitcb_t *output, int context, int minimal)
+static int make_diff_str(char *str1, size_t size1, char *str2, size_t size2, xdemitcb_t *output, int context, int minimal)
 {
 	mmfile_t file1, file2;
 	xpparam_t params;
@@ -911,7 +927,7 @@ out:
 	return result;
 }
 
-static int make_bdiff_str(char *str1, int size1, char *str2, int size2, xdemitcb_t *output)
+static int make_bdiff_str(char *str1, size_t size1, char *str2, size_t size2, xdemitcb_t *output)
 {
 	mmfile_t file1, file2;
 	bdiffparam_t params;
@@ -968,7 +984,7 @@ out:
 	return result;
 }
 
-static int make_rabdiff_str(char *str1, int size1, char *str2, int size2, xdemitcb_t *output)
+static int make_rabdiff_str(char *str1, size_t size1, char *str2, size_t size2, xdemitcb_t *output)
 {
 	mmfile_t file1, file2;
 	int retval, result = 0;
@@ -1022,7 +1038,7 @@ out:
 	return result;
 }
 
-static int make_patch_str(char *file, int size1, char *patch, int size2, xdemitcb_t *output, xdemitcb_t *error, int flags)
+static int make_patch_str(char *file, size_t size1, char *patch, size_t size2, xdemitcb_t *output, xdemitcb_t *error, int flags)
 {
 	mmfile_t file_mm, patch_mm;
 	int retval, result = 0;
@@ -1076,7 +1092,7 @@ out:
 	return result;
 }
 
-static int make_bpatch_str(char *file, int size1, char *patch, int size2, xdemitcb_t *output)
+static int make_bpatch_str(char *file, size_t size1, char *patch, size_t size2, xdemitcb_t *output)
 {
 	mmfile_t file_mm, patch_mm;
 	int retval, result = 0;
@@ -1136,7 +1152,7 @@ out:
 	return result;
 }
 
-static int make_merge3_str(char *content1, int size1, char *content2, int size2, char *content3, int size3, xdemitcb_t *output, xdemitcb_t *error)
+static int make_merge3_str(char *content1, size_t size1, char *content2, size_t size2, char *content3, size_t size3, xdemitcb_t *output, xdemitcb_t *error)
 {
 	mmfile_t file1, file2, file3;
 	int retval, result = 0;

--- a/xdiff.c
+++ b/xdiff.c
@@ -787,9 +787,17 @@ static int append_string(void *ptr, mmbuffer_t *buffer, int array_size)
 {
 	struct string_buffer *string = ptr;
 	void *new_ptr;
-	unsigned int i;
+	int i;
+
+	if (array_size <= 0)
+		return 0;
 
 	for (i = 0; i < array_size; i++) {
+		if (buffer[i].size < 0 || (size_t) buffer[i].size > SIZE_MAX - string->size - 1) {
+			efree(string->ptr);
+			string->ptr = NULL;
+			return -1;
+		}
 		new_ptr = erealloc(string->ptr, string->size + buffer[i].size + 1);
 		if (!new_ptr) {
 			efree(string->ptr);
@@ -801,9 +809,7 @@ static int append_string(void *ptr, mmbuffer_t *buffer, int array_size)
 		memcpy(string->ptr + string->size, buffer[i].ptr, buffer[i].size);
 		string->size += buffer[i].size;
 	}
-	if (array_size) {
-		string->ptr[string->size] = '\0';
-	}
+	string->ptr[string->size] = '\0';
 
 	return 0;
 }
@@ -811,7 +817,10 @@ static int append_string(void *ptr, mmbuffer_t *buffer, int array_size)
 static int append_stream(void *ptr, mmbuffer_t *buffer, int array_size)
 {
 	php_stream *stream = ptr;
-	unsigned int i;
+	int i;
+
+	if (array_size <= 0)
+		return 1;
 
 	for (i = 0; i < array_size; i++) {
 		php_stream_write(stream, buffer[i].ptr, buffer[i].size);

--- a/xdiff.c
+++ b/xdiff.c
@@ -71,11 +71,11 @@ extern char libxdiff_version[];
 
 struct string_buffer {
 	char *ptr;
-	unsigned long size;
+	size_t size;
 };
 
 static int load_mm_file(const char *filepath, mmfile_t *dest);
-static int load_into_mm_file(const char *buffer, unsigned long size, mmfile_t *dest);
+static int load_into_mm_file(const char *buffer, size_t size, mmfile_t *dest);
 static int append_string(void *ptr, mmbuffer_t *buffer, int array_size);
 static int append_stream(void *ptr, mmbuffer_t *buffer, int array_size);
 static int init_string(struct string_buffer *string);
@@ -732,8 +732,10 @@ static int load_mm_file(const char *filepath, mmfile_t *dest)
 		goto out_stream_close;
 
 	filesize = stat.sb.st_size;
+	if (filesize < 0 || filesize > LONG_MAX)
+		goto out_stream_close;
 
-	retval = xdl_init_mmfile(dest, filesize, XDL_MMF_ATOMIC);
+	retval = xdl_init_mmfile(dest, (long) filesize, XDL_MMF_ATOMIC);
 	if (retval < 0)
 		goto out_stream_close;
 
@@ -756,12 +758,15 @@ out:
 	return 0;
 }
 
-static int load_into_mm_file(const char *buffer, unsigned long size, mmfile_t *dest)
+static int load_into_mm_file(const char *buffer, size_t size, mmfile_t *dest)
 {
 	int retval;
 	void *ptr;
 
-	retval = xdl_init_mmfile(dest, size, XDL_MMF_ATOMIC);
+	if (size > LONG_MAX)
+		goto out;
+
+	retval = xdl_init_mmfile(dest, (long) size, XDL_MMF_ATOMIC);
 	if (retval < 0)
 		goto out;
 


### PR DESCRIPTION
## Fix memory safety issues in xdiff.c

### Summary

- Fix inverted return value in `xdiff_file_bpatch()` (returned true on failure, false on success)
- Fix missing error checks in `xdiff_string_diff()`, `xdiff_string_bdiff()`, `xdiff_string_rabdiff()` that could return partial buffer contents instead of false on internal failure
- Fix potential double-free and size overflow in `append_string()`
- Fix unchecked `php_stream_read()` return in `load_mm_file()` that could pass uninitialized memory to libxdiff on short/failed reads
- Fix `int` → `size_t` truncation in all `make_*_str()` helper size parameters to match `zend_string->len`

### Details

**`xdiff_file_bpatch()`: inverted success/failure return**. `make_bpatch()` returns 1 on success and 0 on failure (like every other `make_*` function), but `xdiff_file_bpatch()` tested `retval == 0` to set `RETVAL_TRUE`. This meant the function returned `true` when the patch failed and `false` when it succeeded. Changed to `if (retval)`.

**`xdiff_string_diff/bdiff/rabdiff()`: unchecked `make_*_str()` return**. These three functions ignored the return value of their internal `make_*_str()` call and unconditionally executed `RETVAL_STRINGL()` on the output buffer. On an internal libxdiff failure, `RETVAL_FALSE` (set earlier) would be silently overwritten with whatever partial data was in the buffer. Added `if (!retval) goto out_free_string` to preserve the `false` return on error.

**`append_string()`: double-free and size overflow**. When `erealloc` returned NULL, the code called `efree(string->ptr)` but left `string->ptr` as a dangling pointer. The caller's cleanup path (`free_string`) would then `efree` the same pointer again. Added `string->ptr = NULL` after the `efree`. Additionally, the `erealloc` size computation `string->size + buffer[i].size + 1` had no overflow check if the sum wraps past `SIZE_MAX`, `erealloc` receives a tiny size and the subsequent `memcpy` writes past the end of the buffer (heap overflow). Added a `SIZE_MAX` bounds check before the allocation.

**`load_mm_file()`: unchecked `php_stream_read()` return**. The return value of `php_stream_read()` was discarded. If the read returned fewer bytes than `filesize` (I/O error, truncated file), the remainder of the mmfile buffer would contain uninitialized memory passed to libxdiff. Added a check that the read returned exactly `filesize` bytes, failing cleanly otherwise.

**`int`/`unsigned long` size types throughout**. All `make_*_str()` functions took `int` for their size parameters, but callers pass `zend_string->len` which is `size_t`. On 64-bit platforms this silently truncates strings larger than 2GB. Changed all size parameters from `int` to `size_t`. Also changed `struct string_buffer.size` and `load_into_mm_file()` size parameter from `unsigned long` to `size_t` for consistency. Since libxdiff's API (`xdl_init_mmfile`, `xdl_mmfile_writeallocate`) uses `long` internally, added explicit `LONG_MAX` bounds checks in both `load_mm_file()` and `load_into_mm_file()` before calling into libxdiff to prevent truncation on LLP64 platforms (Windows) where `long` is 32-bit.

### Test plan

- [x] `make test` : 40/40 pass (39 existing + 1 new)
- [x] `make test TESTS="-m"` (valgrind) : 40/40 pass, 0 leaks
- [x] ASAN build : 40/40 pass, no xdiff-related errors (only benign OpenSSL global allocation noise)
- [x] New test `tests/file_bpatch_retval.phpt` verifies `xdiff_file_bpatch()` returns `true` on success and `false` on invalid patch input